### PR TITLE
Simplify module installation

### DIFF
--- a/files/common.sh
+++ b/files/common.sh
@@ -27,6 +27,10 @@ if tput colors &>/dev/null; then
   reset="$(tput sgr0)"
 fi
 
+version_gt() {
+  test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"
+}
+
 _tmp="$(mktemp)"
 exec 2>>"$_tmp"
 

--- a/tasks/collect.json
+++ b/tasks/collect.json
@@ -7,6 +7,6 @@
     }
 
   },
-  "supports_noop": false,
-  "files": ["pe_tech_check/files/common.sh", "pe_tech_check/files/get_version.rb"]
+  "files": ["pe_tech_check/files/common.sh"],
+  "supports_noop": false
 }

--- a/tasks/configure.json
+++ b/tasks/configure.json
@@ -6,7 +6,7 @@
        "type": "Optional[Variant[Enum['true','false']]]"
      },
      "install_pe_tune": {
-       "description": "Install the 'puppet pe tune' module. Defaults to 'true'",
+       "description": "Install the 'puppet pe tune' module, if necessary. Defaults to 'true'",
        "type": "Optional[Variant[Enum['true','false']]]"
      }
   },

--- a/tasks/configure.sh
+++ b/tasks/configure.sh
@@ -1,65 +1,22 @@
 #!/bin/bash
 
+# NOTE: this script can be skipped entirely if the metrics collector is already installed
+# Otherwise, run `bolt task run pe_tech_check::configure --nodes localhost` from inside a Boltdir
+# with puppet_metrics_collector installed to ./modules
+
 (( $EUID == 0 )) || fail "This utility must be run as root"
 
 declare PT__installdir
 source "$PT__installdir/pe_tech_check/files/common.sh"
 [[ $PATH =~ "/opt/puppetlabs/bin" ]] || export PATH="/opt/puppetlabs/bin:${PATH}"
 
-tmp_dir=/var/tmp/puppet_modules
-metrics_version='5.1.2'
-pe_tune_version='2.3.0'
-
-module_path="$(puppet config print modulepath)" || module_path=
-# This really only checks the return code of mapfile, which is ok
-# The proper way to do this would be with `jq` and puppet module list --render-as json
-mapfile -t module_list < <(puppet module list --modulepath="${tmp_dir}:${module_path}" 2>/dev/null) || {
-  fail "Error getting module list"
-}
-
-[[ -d $tmp_dir ]] || {
-  mkdir "$tmp_dir" || fail "Error creating temp directory"
-}
-
 # The install_* task parameters default to true.
-# Install to $tmp_dir if install_pe_metrics is not false and neither of the collection modules are not installed
-if [[ $install_pe_metrics != "false" ]]; then
-  if [[ ! ${module_list[@]} =~ 'pe_metric_curl_cron_jobs'|'puppet_metrics_collector' ]]; then
-    puppet module install puppetlabs-puppet_metrics_collector \
-      --version "$metrics_version" --modulepath="$tmp_dir" >/dev/null || {
-      fail "Error installing the 'puppet_metrics_collector' module, please install manually"
-    }
-fi
-
-  # Update module_list in case we installed metrics collection
-  mapfile -t module_list < <(puppet module list --modulepath="${tmp_dir}:${module_path}" 2>/dev/null) || {
-    fail "Error getting module list"
-  }
-
-  # If only the puppet_metrics_collector module is installed, configure it if necessary
-  if [[ ! ${module_list[@]} =~ 'pe_metric_curl_cron_jobs' && ${module_list[@]} =~ 'puppet_metrics_collector' ]]; then
-    crontab -l | grep -q 'puppetserver_metrics' || {
-      puppet apply -e "class { 'puppet_metrics_collector': }" --modulepath="${tmp_dir}:${module_path}" >/dev/null || {
-        fail "Error configuring the 'puppet_metrics_collector' module, please install manually"
-      }
-    }
-    fi
-  fi
-
-if [[ "$install_pe_tune" != "false" ]]; then
-  [[ -d ${tmp_dir}/pe_tune ]] || mkdir "$tmp_dir/pe_tune"
-  _tmp_tune="$(mktemp)"
-  _tmp_tune_dir="$(mktemp -d)"
-
-  curl -sL -o "$_tmp_tune" "https://github.com/tkishel/pe_tune/archive/${pe_tune_version}.tar.gz" || {
-    fail "Error downloading tarball"
-  }
-
-  tar xf "$_tmp_tune" -C "$_tmp_tune_dir" || fail "Error extracting tarball"
-
-  find "$tmp_dir/pe_tune" -mindepth 1 -delete
-  # Use wildcards so we don't have to care about the version number
-  mv -f "$_tmp_tune_dir/"*/* "$tmp_dir/pe_tune" || fail "Error installing the 'pe_tune' module, please install manually"
+# If neither metrics collection module is installed and $install_pe_metrics != "false":
+# apply the 'puppet_metrics_collector' class from ./modules acquired via `bolt puppetfile install`
+if ! [[ -e /opt/puppetlabs/puppet-metrics-collector || -e /opt/puppetlabs/pe_metric_curl_cron_jobs ]] && [[ $install_pe_metrics != "false" ]]; then
+   puppet apply -e "class { 'puppet_metrics_collector': }" --modulepath="./modules" >/dev/null || {
+   fail "Error configuring the 'puppet_metrics_collector' module, please install manually"
+   }
 fi
 
 success '{ "status": "PE Tech Check configured successfully" }'


### PR DESCRIPTION
In general, we should be leveraging module installation via a Puppetfile instead of downloading, extracting, and copying it via shell code.  We can yank out a bunch of code by doing that.

Also, use a bash version comparison function to select the appropriate support script command and decide whether to use the vendored tune command or the module.